### PR TITLE
Update set_env.sh with `#!/bin/bash`

### DIFF
--- a/extras/set_env.sh
+++ b/extras/set_env.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 PARENT_DIR=$(dirname "$SCRIPT_DIR")/src
 


### PR DESCRIPTION
Simple `#!/bin/bash`. This should fix bugs that I encountered like:

```bash
a@b~/OGHarn (main)> ./extras/set_env.sh

./extras/set_env.sh
./extras/set_env.sh: 1: Bad substitution
./extras/set_env.sh: 10: source: not found
```